### PR TITLE
Avoid clearing preedit for modifier shortcuts

### DIFF
--- a/src/engine/core/src/lib.rs
+++ b/src/engine/core/src/lib.rs
@@ -145,6 +145,15 @@ impl InputEngine {
             ret |= InputResult::CONSUMED;
         } else if key.code == KeyCode::Shift {
             // ignore shift key
+        } else if key
+            .state
+            .intersects(ModifierState::CONTROL | ModifierState::ALT | ModifierState::SUPER)
+            || matches!(
+                key.code,
+                KeyCode::ControlL | KeyCode::ControlR | KeyCode::AltL | KeyCode::AltR
+            )
+        {
+            // keep preedit for modifier assisted keys so shortcuts like Ctrl+C bypass cleanly
         } else {
             // clear preedit when get unhandled key
             self.clear_preedit();


### PR DESCRIPTION
## Summary
- stop clearing the preedit buffer for keys pressed with Control/Alt/Super modifiers so shortcut bypasses keep their selection

## Testing
- cargo test *(fails: missing system library `dbus-1` required by `libdbus-sys` build script)*

------
https://chatgpt.com/codex/tasks/task_e_68cb96e5e4bc832fa95396b0105c1897